### PR TITLE
BRL-11296: Fix bounded per-context tags association returning duplicates

### DIFF
--- a/lib/acts-as-taggable-on/taggable.rb
+++ b/lib/acts-as-taggable-on/taggable.rb
@@ -112,7 +112,7 @@ module ActsAsTaggableOn
           tags = ActsAsTaggableOn::Tag.select("tags.*")
 
           if bounded_tags?
-            tags.joins(:tag_bounds).where("`tag_bounds`.`class_name` = ?", self.to_s)
+            tags.joins(:tag_bounds).where("tag_bounds.class_name = ?", self.to_s)
           else
             tags
           end

--- a/lib/acts-as-taggable-on/taggable/core.rb
+++ b/lib/acts-as-taggable-on/taggable/core.rb
@@ -50,13 +50,12 @@ module ActsAsTaggableOn
 
               has_many context_tags,
               -> {
-                if bound_class_name.nil?
-                  order(taggings_order)
-                else
-                  joins(:tag_bounds)
-                  .where("`tag_bounds`.`class_name` = ?", bound_class_name)
-                  .order(taggings_order)
-                end
+                # The `through: context_taggings` association already restricts results to
+                # tags bound to this class (it joins and filters tag_bounds by class_name).
+                # Re-joining tag_bounds here added a second join that ActiveRecord aliases
+                # and leaves unfiltered by class_name, so a tag bound to N classes was
+                # returned N times. Just order; the through handles the bounding.
+                order(taggings_order)
               },
               class_name: 'ActsAsTaggableOn::Tag',
               through: context_taggings,

--- a/lib/acts-as-taggable-on/taggable/core.rb
+++ b/lib/acts-as-taggable-on/taggable/core.rb
@@ -37,7 +37,7 @@ module ActsAsTaggableOn
                     .where(context: tags_type)
                   else
                     joins("INNER JOIN tag_bounds ON tag_bounds.tag_id = taggings.tag_id")
-                    .where("`tag_bounds`.`class_name` = ?", bound_class_name)
+                    .where("tag_bounds.class_name = ?", bound_class_name)
                     .includes(:tag).order(taggings_order)
                     .where(context: tags_type)
                   end
@@ -218,7 +218,7 @@ module ActsAsTaggableOn
       def tags_on(context)
         scope = base_tags
         if self.class.bounded_tags?
-          scope = scope.joins("JOIN tag_bounds ON `tag_bounds`.`tag_id` = tags.id").where("`tag_bounds`.`class_name` = ?", self.class.to_s)
+          scope = scope.joins("JOIN tag_bounds ON tag_bounds.tag_id = tags.id").where("tag_bounds.class_name = ?", self.class.to_s)
         end
         scope = scope.where(["#{ActsAsTaggableOn::Tagging.table_name}.context = ? AND #{ActsAsTaggableOn::Tagging.table_name}.tagger_id IS NULL", context.to_s])
         # when preserving tag order, return tags in created order

--- a/spec/acts_as_taggable_on/bounded_taggable_spec.rb
+++ b/spec/acts_as_taggable_on/bounded_taggable_spec.rb
@@ -1,0 +1,43 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+describe 'Bounded taggable' do
+  let(:model) { BoundedTaggableModel.create!(name: 'Bob') }
+
+  it 'only returns tags bound to its own class' do
+    model.language_list = 'ruby, python'
+    model.save!
+
+    expect(model.reload.languages.map(&:name)).to contain_exactly('ruby', 'python')
+  end
+
+  it 'creates a tag_bound for the taggable class' do
+    model.language_list = 'ruby'
+    model.save!
+
+    tag = ActsAsTaggableOn::Tag.find_by(name: 'ruby')
+    expect(tag.tag_bounds.pluck(:class_name)).to include('BoundedTaggableModel')
+  end
+
+  # Regression: a global Tag can be bound to more than one class (the same tag
+  # name reused across taggable models). The per-context association must not
+  # return that tag once per bound class.
+  context 'when a tag is also bound to another class' do
+    before do
+      model.language_list = 'ruby'
+      model.save!
+
+      tag = ActsAsTaggableOn::Tag.find_by!(name: 'ruby')
+      tag.tag_bounds.create!(class_name: 'SomeOtherModel')
+    end
+
+    it 'returns the tag exactly once' do
+      expect(model.reload.languages.map(&:name)).to eq(['ruby'])
+    end
+
+    it 'does not multiply the tagging count' do
+      expect(model.reload.languages.size).to eq(1)
+    end
+  end
+end

--- a/spec/internal/app/models/bounded_taggable_model.rb
+++ b/spec/internal/app/models/bounded_taggable_model.rb
@@ -1,0 +1,3 @@
+class BoundedTaggableModel < ActiveRecord::Base
+  acts_as_bounded_ordered_taggable_on :languages
+end

--- a/spec/internal/db/schema.rb
+++ b/spec/internal/db/schema.rb
@@ -80,6 +80,11 @@ ActiveRecord::Schema.define version: 0 do
     t.column :name, :string
   end
 
+  create_table :bounded_taggable_models, force: true do |t|
+    t.column :name, :string
+    t.column :type, :string
+  end
+
   create_table :users, force: true do |t|
     t.column :name, :string
   end


### PR DESCRIPTION
## Problem

The bounded per-context tags association (defined by `acts_as_bounded_taggable_on` / `acts_as_bounded_ordered_taggable_on`) returns a tag **once per class it is bound to** instead of once. A global `Tag` can be bound to multiple classes (the same tag name reused across taggable models), and in that case e.g. `supplier.search_tags` yields `["Preferred", "Preferred", ...]`.

Surfaced downstream by BRL-11272 (supplier tagging): the admin Supplier show page rendered `Search Tags: Preferred Vendor, Preferred Vendor`. The edit form was unaffected because it reads `*_list`, which dedupes via `TagList#uniq!`.

### Administering the tag list
<img width="618" height="83" alt="image" src="https://github.com/user-attachments/assets/f6e1a399-0d95-4196-aa6c-693ec0f4e9c7" />

### Viewing the tag list
<img width="530" height="411" alt="image" src="https://github.com/user-attachments/assets/bf896607-ebf6-4a87-a26b-36ce8f16373b" />


## Root cause

In `lib/acts-as-taggable-on/taggable/core.rb`, the `context_tags` association re-joined `tag_bounds` in its own scope:

```ruby
has_many context_tags, -> {
  joins(:tag_bounds).where("`tag_bounds`.`class_name` = ?", bound_class_name).order(taggings_order)
}, through: context_taggings, source: :tag
```

But `through: context_taggings` **already** joins and filters `tag_bounds` by `class_name`. ActiveRecord aliases the second join (`tag_bounds_tags`) and never applies the `class_name` filter to it, producing a cartesian: one row per `tag_bounds` row for the tag.

```sql
INNER JOIN `tag_bounds` `tag_bounds_tags` ON `tag_bounds_tags`.`tag_id` = `tags`.`id`   -- from context_tags scope, UNFILTERED
INNER JOIN tag_bounds ON tag_bounds.tag_id = taggings.tag_id                            -- from through, filtered
WHERE ... (`tag_bounds`.`class_name` = 'Supplier') ...
```

## Fix

Remove the redundant join from `context_tags` — the `through:` association already enforces the bound. Behavior-preserving: the same tag *set* is returned, just without the bogus multiplicity.

## Tests

- Added a bounded taggable test model (`BoundedTaggableModel`), its table, and specs.
- Regression spec: a tag bound to more than one class is now returned exactly once. It fails on the previous code (returns the tag twice) and passes here.
- Full suite green: `299 examples, 0 failures` (1 pre-existing pending).

🤖 Generated with [Claude Code](https://claude.com/claude-code)